### PR TITLE
Fix useToast listener cleanup

### DIFF
--- a/src/hooks/use-toast.ts
+++ b/src/hooks/use-toast.ts
@@ -171,6 +171,9 @@ function toast({ ...props }: Toast) {
 function useToast() {
   const [state, setState] = React.useState<State>(memoryState)
 
+  // Subscribe to toast state updates once on mount. Using an empty
+  // dependency array prevents repeatedly adding the same listener
+  // whenever state changes, which previously caused a memory leak.
   React.useEffect(() => {
     listeners.push(setState)
     return () => {
@@ -179,7 +182,7 @@ function useToast() {
         listeners.splice(index, 1)
       }
     }
-  }, [state])
+  }, [])
 
   return {
     ...state,


### PR DESCRIPTION
## Summary
- fix `useToast` subscription effect dependencies to avoid memory leak

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run build` *(fails: vite: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68467f7deda8832aa62ad642f6bdd475